### PR TITLE
Incluindo preços do BrazilJS 2016

### DIFF
--- a/_data/events/braziljs2016.yml
+++ b/_data/events/braziljs2016.yml
@@ -1,5 +1,6 @@
 name: BrazilJS
 date: 26/08/2016, 27/08/2016
+price: 50, 125, 250, 300
 url: https://braziljs.org/conf
 img: https://res.cloudinary.com/dxncj4eza/image/upload/v1452777310/cpxhe5twcbnuzhlvbxkl.png
 description: O maior evento de JS do mundo.


### PR DESCRIPTION
Incluindo preço dos ingressos do BrazilJS 2016, que vão de R$ 50 até R$ 300.
Ingressos estão disponíveis em: http://www.eventick.com.br/braziljs-2016.