### PR TITLE
Ajustando preços do RSJS 2016

### DIFF
--- a/_data/events/rsjs2016.yml
+++ b/_data/events/rsjs2016.yml
@@ -2,7 +2,7 @@ name: RSJS
 date: 23/04/2016
 location: Senac, Auditório Master - Prédio A
 address: Rua Cel. Genuíno, 130, Porto Alegre, Rio Grande do Sul
-price: 49, 79
+price: 50, 90
 url: http://rsjs.org/2016/
 img: http://rsjs.org/images/og-image.jpg
 description: Quinta edição do mais tradicional evento gaudério de JavaScript do Rio Grande do Sul.


### PR DESCRIPTION
Ajustando preços do evento RSJS 2016 para valor entre 50 e 90 reais.